### PR TITLE
add  vm.overcommit_memory=1

### DIFF
--- a/user_data
+++ b/user_data
@@ -21,6 +21,7 @@ write_files:
     content: |
       fs.aio-max-nr=1048576
       vm.max_map_count=262144
+      vm.overcommit_memory=1
   - path: /etc/hosts
     permissions: 0644
     owner: root


### PR DESCRIPTION
as is recommanded by REDIS
# WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.