### PR TITLE
disable transparent hugepage

### DIFF
--- a/user_data
+++ b/user_data
@@ -50,6 +50,11 @@ write_files:
       MAIL_PASS=
       MAIL_HOST=mail.indie.host
       MAIL_PORT=587
+  - path: /sys/kernel/mm/transparent_hugepage/enabled
+    permission: 0644
+    owner: root
+    content: |
+      never
 coreos:
   update:
     reboot-strategy: off


### PR DESCRIPTION
as recommanded by REDIS
\# WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.