### PR TITLE
vm.overcommit_memory & transparent_hugepage

### DIFF
--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -31,9 +31,12 @@ systemctl restart sshd
 cat > /etc/sysctl.d/libresh.conf <<EOF
 fs.aio-max-nr=1048576
 vm.max_map_count=262144
+vm.overcommit_memory=1
 EOF
 chmod 644 /etc/sysctl.d/libresh.conf
 sysctl -p
+
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
 ```
 
 # define Localhost


### PR DESCRIPTION
as recommanded by REDIS
\# WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.

\# WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.